### PR TITLE
Removing namespace - Fixes error with use_tulip=True

### DIFF
--- a/config/rviz/robile.rviz
+++ b/config/rviz/robile.rviz
@@ -8,9 +8,9 @@ Panels:
         - /Status1
         - /RobotModel1
         - /TF1/Tree1
-        - /TF1/Tree1/map1
-        - /TF1/Tree1/map1/odom1
-        - /TF1/Tree1/map1/odom1/base_link1
+        - /LaserScan1
+        - /PoseArray1
+        - /GlobalPlan1
         - /local_foot_print1
       Splitter Ratio: 0.33392226696014404
     Tree Height: 1085
@@ -194,7 +194,7 @@ Visualization Manager:
       Selectable: true
       Size (Pixels): 3
       Size (m): 0.009999999776482582
-      Style: Flat Squares
+      Style: Points
       Topic: /robile_john/scan_front
       Unreliable: false
       Use Fixed Frame: true
@@ -230,7 +230,7 @@ Visualization Manager:
           Scale: 1
           Value: true
         Value: true
-      Enabled: false
+      Enabled: true
       Head Length: 0.30000001192092896
       Head Radius: 0.10000000149011612
       Name: PoseWithCovariance
@@ -240,14 +240,14 @@ Visualization Manager:
       Shape: Arrow
       Topic: /robile_john/amcl_pose
       Unreliable: false
-      Value: false
+      Value: true
     - Alpha: 1
       Arrow Length: 0.30000001192092896
       Axes Length: 0.30000001192092896
       Axes Radius: 0.009999999776482582
       Class: rviz/PoseArray
       Color: 255; 25; 0
-      Enabled: false
+      Enabled: true
       Head Length: 0.07000000029802322
       Head Radius: 0.029999999329447746
       Name: PoseArray
@@ -257,7 +257,7 @@ Visualization Manager:
       Shape: Arrow (Flat)
       Topic: /robile_john/particlecloud
       Unreliable: false
-      Value: false
+      Value: true
     - Alpha: 1
       Buffer Length: 1
       Class: rviz/Path
@@ -279,7 +279,7 @@ Visualization Manager:
       Radius: 0.029999999329447746
       Shaft Diameter: 0.10000000149011612
       Shaft Length: 0.10000000149011612
-      Topic: /move_base/DWAPlannerROS/global_plan
+      Topic: /move_base/NavfnROS/plan
       Unreliable: false
       Value: true
     - Alpha: 1
@@ -344,6 +344,23 @@ Visualization Manager:
       Topic: /move_base/local_costmap/footprint
       Unreliable: false
       Value: true
+    - Alpha: 1
+      Arrow Length: 0.30000001192092896
+      Axes Length: 0.30000001192092896
+      Axes Radius: 0.009999999776482582
+      Class: rviz/PoseArray
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.07000000029802322
+      Head Radius: 0.029999999329447746
+      Name: PoseArray
+      Queue Size: 10
+      Shaft Length: 0.23000000417232513
+      Shaft Radius: 0.009999999776482582
+      Shape: Arrow (Flat)
+      Topic: /particlecloud
+      Unreliable: false
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -371,7 +388,7 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Angle: -0.1750001311302185
+      Angle: -3.7499983310699463
       Class: rviz/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
@@ -381,10 +398,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 106.95951843261719
+      Scale: -18.706844329833984
       Target Frame: <Fixed Frame>
-      X: -4.470522981137037e-05
-      Y: 6.210674996509624e-07
+      X: 12.590354919433594
+      Y: 28.280527114868164
     Saved: ~
 Window Geometry:
   Displays:

--- a/launch/platform_independent/robile_gazebo.launch
+++ b/launch/platform_independent/robile_gazebo.launch
@@ -19,7 +19,7 @@
     <arg name="start_rviz" default="true"/>
     <arg name="rviz_config" default="$(find robile_gazebo)/config/rviz/robile.rviz"/>
 
-    <group ns="$(arg robot_name_1)">
+    <include file="$(find robile_gazebo)/launch/platform_independent/world.launch" pass_all_args="true"/>
     <!-- launch robot in Gazebo -->
         <param if="$(arg use_kelo_tulip)" name="robot_description"
             command="$(find xacro)/xacro '$(find robile_description)/gazebo/gazebo_robile_laser_scanner.xacro' platform_config:=$(arg platform_config)"/>
@@ -56,6 +56,7 @@
             <node name="robile_ros_controller_spawner" pkg="controller_manager" type="spawner" output="screen" 
             args="joint_state_controller $(arg hub_wheel_controller_list)" />
         </group>
+    <group ns="$(arg robot_name_1)">
     </group>	
 
 </launch>


### PR DESCRIPTION
removing namespace. 

fixes error : 
odom missing in tf tree
navigation failure becauce of tf error 